### PR TITLE
feat: allow timestamps_unix in model and migration

### DIFF
--- a/src/clear/migration/operation/table.cr
+++ b/src/clear/migration/operation/table.cr
@@ -32,6 +32,13 @@ module Clear::Migration
       add_index(["updated_at"])
     end
 
+    def timestamps_unix(null = false)
+      add_column(:created_at, :bigint, null: null, default: "EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)")
+      add_column(:updated_at, :bigint, null: null, default: "EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)")
+      add_index(["created_at"])
+      add_index(["updated_at"])
+    end
+
     def references(to, name : String? = nil, on_delete = "restrict", type = "bigint",
                    null = false, foreign_key = "id", primary = false)
       name ||= to.singularize.underscore + "_id"

--- a/src/clear/model/modules/has_timestamps.cr
+++ b/src/clear/model/modules/has_timestamps.cr
@@ -33,4 +33,36 @@ module Clear::Model::HasTimestamps
     end
 
   end
+
+  macro timestamps_unix
+    column( updated_at : Int64 )
+    column( created_at : Int64 )
+
+    before(:validate) do |model|
+      model = model.as(self)
+
+      unless model.persisted?
+        now = Time.local.to_unix
+        model.created_at = now unless model.created_at_column.defined?
+        model.updated_at = now unless model.updated_at_column.defined?
+      end
+    end
+
+    after(:validate) do |model|
+      model = model.as(self)
+
+      # In the case the updated_at has been changed, we do not override.
+      # It happens on first insert, in the before validation setup.
+      model.updated_at = Time.local.to_unix if model.changed? && !model.updated_at_column.changed?
+    end
+
+    # Saves the record with the updated_at set to the current time.
+    def touch(now = Time.local.to_unix) : Clear::Model
+      self.updated_at = now
+      self.save!
+
+      self
+    end
+
+  end
 end


### PR DESCRIPTION
- Allow `macro timestamps_unix` in model to map against Unix timestamps from DB
- Allow `def timestamps_unix` in migration to get current_timestamp in UNIX format in DB auto-insertion